### PR TITLE
Review of code prepped for CAP phase 1C #2

### DIFF
--- a/azure-storage/README.md
+++ b/azure-storage/README.md
@@ -1,36 +1,39 @@
 # Azure deployment
 This deployment includes deploying a storage account blob only under it's own resource group in canadacentral.  This is to be used for storage migration as part of the CWU Cloud Discovery project.
 
+## Terraform and Azure-CLI automated installations
+Run `install-prereqs.sh` to have these auto-installed for you
+
+## Terraform and Azure-CLI manual installation
 These are instructions for linux-based machines, however provider documentation is linked below if you want to run from another platform
 
-
-## Terraform
 Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html)
 ```
 wget https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_linux_amd64.zip
 unzip terraform_0.12.7_linux_amd64.zip
-sudo mv terraform /usr/local/bin/terraform
+mv terraform ~
+```
+
+Install [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+```
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 ```
 
 
 ## Setting up prereqs for Azure provider
-1. Install [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
-```
-curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-```
-2. Login via Azure CLI
+1. Login via Azure CLI
 ```
 az login
 ```
-3. Grab your subscription id from the output of the following command
+2. Grab your subscription id from the output of the following command
 ```
 az account list
 ```
-4. Create new service principal, this is the account we'll use to create and delete resources via Terraform
+3. Create new service principal, this is the account we'll use to create and delete resources via Terraform
 ```
 az ad sp create-for-rbac --name cwu_terraform --role="Contributor" --scopes="/subscriptions/<SUBSCRIPTION_ID from above>"
 ```
-5. This will print a JSON payload similar to the following
+4. This will print a JSON payload similar to the following
 ```
 {
   "appId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
@@ -40,7 +43,7 @@ az ad sp create-for-rbac --name cwu_terraform --role="Contributor" --scopes="/su
   "tenant": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 }
 ```
-6. Capture the appId, password and tenant.  Export them as follows
+5. Capture the appId, password and tenant.  Export them as follows
 ```
 export ARM_CLIENT_ID=<insert the appId from above>
 export ARM_SUBSCRIPTION_ID=<insert your subscription id>
@@ -67,3 +70,11 @@ Note that for integration into an application for use as an object store, for th
 ```
 azure storage account name == s3 access key
 azure storage access key == s3 secret key
+```
+
+## Run terraform to deprovision resources
+```
+terraform destroy
+
+```
+Have to type 'yes' for this to kick off after reviewing the plan.  This part will take a few mins

--- a/azure-storage/README.md
+++ b/azure-storage/README.md
@@ -1,0 +1,69 @@
+# Azure deployment
+This deployment includes deploying a storage account blob only under it's own resource group in canadacentral.  This is to be used for storage migration as part of the CWU Cloud Discovery project.
+
+These are instructions for linux-based machines, however provider documentation is linked below if you want to run from another platform
+
+
+## Terraform
+Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html)
+```
+wget https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_linux_amd64.zip
+unzip terraform_0.12.7_linux_amd64.zip
+sudo mv terraform /usr/local/bin/terraform
+```
+
+
+## Setting up prereqs for Azure provider
+1. Install [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+```
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+```
+2. Login via Azure CLI
+```
+az login
+```
+3. Grab your subscription id from the output of the following command
+```
+az account list
+```
+4. Create new service principal, this is the account we'll use to create and delete resources via Terraform
+```
+az ad sp create-for-rbac --name cwu_terraform --role="Contributor" --scopes="/subscriptions/<SUBSCRIPTION_ID from above>"
+```
+5. This will print a JSON payload similar to the following
+```
+{
+  "appId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "displayName": "cwu_terraform",
+  "name": "http://cwu_terraform",
+  "password": "xxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "tenant": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
+6. Capture the appId, password and tenant.  Export them as follows
+```
+export ARM_CLIENT_ID=<insert the appId from above>
+export ARM_SUBSCRIPTION_ID=<insert your subscription id>
+export ARM_TENANT_ID=<insert the tenant from above>
+export ARM_CLIENT_SECRET=<insert the password from above>
+export TF_VAR_service_principal_client_id=$ARM_CLIENT_ID
+export TF_VAR_service_principal_client_secret=$ARM_CLIENT_SECRET
+export TF_VAR_email_letsencrypt=<your email address>
+```
+
+## Run terraform to deploy the template
+```
+terraform init
+terraform apply
+```
+Have to type 'yes' for this to kick off after reviewing the plan.  This part will take a few mins
+
+Run the following to verify the storage account is available and to obtain access keys
+```
+az storage account keys list --account-name bcgovcapstorage
+```
+
+Note that for integration into an application for use as an object store, for those that are more familiar with other object storage services such as S3 that use access and secret keys the mapping is
+```
+azure storage account name == s3 access key
+azure storage access key == s3 secret key

--- a/azure-storage/install-prereqs.sh
+++ b/azure-storage/install-prereqs.sh
@@ -1,0 +1,65 @@
+PACKAGE_MANAGER=""
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Mac OSX
+    PACKAGE_MANAGER="brew";
+elif [[ "$OSTYPE" == "cygwin"* || "$OSTYPE" == "msys"* || "$OSTYPE" == "win"* ]]; then
+    # POSIX compatibility layer and Linux environment emulation for Windows
+    # Lightweight shell and GNU utilities compiled for Windows (part of MinGW)
+    PACKAGE_MANAGER="choco";
+elif [[ "$OSTYPE" == "linux"* ]]; then
+    if grep -qi Microsoft /proc/sys/kernel/osrelease 2> /dev/null; then
+        # Win10 bash
+        PACKAGE_MANAGER="choco";
+    else
+        # Linux
+        DISTRO=$(lsb_release -ds 2>/dev/null || cat /etc/*release 2>/dev/null | head -n1 || uname -om);
+        if [[ "$DISTRO" == *"hat"* || "$DISTRO" == *"centos"* ]]; then
+            PACKAGE_MANAGER="yum";
+        elif [[ "$OSTYPE" == *"debian"* || "$OSTYPE" == *"ubuntu"* ]]; then
+            PACKAGE_MANAGER="apt";
+        fi
+    fi
+elif [[ "$OSTYPE" == "bsd"* || "$OSTYPE" == "solaris"* ]]; then
+    # not supported
+    echo -e \\n"OS not supported. Supported OS:\\nMac OSX\\nWindows\\nDebian\\nFedora\\n"\\n
+    exit 1
+else
+    echo -e \\n"OS not detected. Supported OS:\\nMac OSX\\nWindows\\nDebian\\nFedora\\n"\\n
+    exit 1
+fi
+
+
+if [[ "$PACKAGE_MANAGER" == "brew" ]]; then
+    which -s brew;
+    if [[ $? != 0 ]] ; then
+        # Install Homebrew
+        ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)";
+    fi
+    brew update;
+    brew install terraform azure-cli
+elif [[ "$PACKAGE_MANAGER" == "choco" ]]; then
+    sudo PowerShell -NoProfile -ExecutionPolicy remotesigned -Command ". 'install_choco.ps1;"
+    choco upgrade chocolatey;
+    choco install terraform azure-cli -y;
+elif [[ "$PACKAGE_MANAGER" == "yum" ]]; then
+    curl -o terraform.zip https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_linux_amd64.zip
+    unzip terraform.zip
+    mv terraform ~
+    rm terraform.zip
+    sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc;
+    sudo sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo';
+    yum check-update;
+    sudo yum -y install azure-cli;
+elif [[ "$PACKAGE_MANAGER" == "apt" ]]; then
+    curl -o terraform.zip https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_linux_amd64.zip
+    unzip terraform.zip
+    mv terraform ~
+    rm terraform.zip
+    curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+else
+    echo -e \\n"Packages not installed.\\n"\\n
+    exit 1
+fi
+
+echo "Finished installing developer prerequisites"

--- a/azure-storage/main.tf
+++ b/azure-storage/main.tf
@@ -1,0 +1,22 @@
+provider "azurerm" {
+  version = "~> 1.33"
+}
+
+resource "azurerm_resource_group" "cap-rg" {
+  name     = "cap-rg"
+  location = "canadacentral"
+}
+
+resource "azurerm_storage_account" "storage" {
+  name                     = "bcgovcapstorage"
+  resource_group_name      = "${azurerm_resource_group.cap-rg.name}"
+  location                 = "${azurerm_resource_group.cap-rg.location}"
+  account_kind             = "BlobStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    project = "cap"
+    environment = "poc"
+  }
+}

--- a/docker-images/minio-benchmark/Dockerfile
+++ b/docker-images/minio-benchmark/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+
+RUN useradd -d /opt/benchmark -g root benchmark
+
+WORKDIR /opt/benchmark
+
+RUN apt-get update && \
+    apt-get install curl -y && \
+    curl -o s3-benchmark https://raw.githubusercontent.com/minio/s3-benchmark/master/s3-benchmark && \
+    chmod +x s3-benchmark
+
+USER benchmark
+
+ENTRYPOINT [ "bash" ]

--- a/openshift/templates/api/cap/minio-eagle-cwu-azure.dc.yaml
+++ b/openshift/templates/api/cap/minio-eagle-cwu-azure.dc.yaml
@@ -1,0 +1,145 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: ${NAME}
+objects:
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        app: ${NAME}
+        deploymentconfig: ${NAME}
+      strategy:
+        activeDeadlineSeconds: 21600
+        recreateParams:
+          timeoutSeconds: 600
+        resources: {}
+        type: Recreate
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: ${NAME}
+            deploymentconfig: ${NAME}
+        spec:
+          containers:
+            - env:
+                - name: MINIO_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: MINIO_AZURE_ACCESS_KEY
+                      name: minio-azure-keys
+                - name: MINIO_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: MINIO_AZURE_SECRET_KEY
+                      name: minio-azure-keys
+                - name: MINIO_CONFIG_DIR
+                  value: /tmp
+                - name: MINIO_DATA_DIR
+                  value: /data
+              image: >-
+                172.50.0.2:5000/openshift/minio@sha256:02f81d40a3515ab8ba4a311d73849e046d5d06cc2d68db938b33af45906fdded
+              imagePullPolicy: Always
+              name: ${NAME}
+              ports:
+                - containerPort: 9000
+                  protocol: TCP
+              resources:
+                limits:
+                  cpu: 150m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              # Next two lines are to override the entrypoint set by the minio image that forces it to run in local server mode
+              # We need it as an azure gateway
+              command: ["/opt/minio/minio"]
+              args: ["gateway", "azure", "--config-dir=${MINIO_CONFIG_DIR}"]
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      test: false
+      triggers:
+        - imageChangeParams:
+            containerNames:
+              - ${NAME}
+            from:
+              kind: ImageStreamTag
+              name: 'minio:stable'
+              namespace: openshift
+          type: ImageChange
+        - type: ConfigChange
+    metadata:
+      annotations:
+        description: Defines how to deploy the minio server
+      generation: 1
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: minio-azure-keys
+      labels:
+        app: "${NAME}"
+    stringData:
+      MINIO_AZURE_ACCESS_KEY: "${MINIO_AZURE_ACCESS_KEY}"
+      MINIO_AZURE_SECRET_KEY: "${MINIO_AZURE_SECRET_KEY}"
+  - apiVersion: v1
+    kind: Service
+    spec:
+      ports:
+        - name: 9000-tcp
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+      selector:
+        deploymentconfig: ${NAME}
+      sessionAffinity: None
+      type: ClusterIP
+    metadata:
+      annotations:
+        description: Exposes the minio server
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    spec:
+      port:
+        targetPort: 9000-tcp
+      tls:
+        termination: edge
+      to:
+        kind: Service
+        name: ${NAME}
+        weight: 100
+      wildcardPolicy: None
+    metadata:
+      annotations:
+        openshift.io/host.generated: 'true'
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+parameters:
+- name: NAME
+  displayName: Name to apply to objects in the template
+  value: cap-minio-eagle-dev-azure
+  required: true
+- name: MINIO_AZURE_ACCESS_KEY
+  displayName: Minio Azure access key
+  generate: expression
+  from: "[a-zA-Z0-9]{8}"
+  required: true
+- name: MINIO_AZURE_SECRET_KEY
+  displayName: Minio Azure secret key
+  generate: expression
+  from: "[a-zA-Z0-9]{16}"
+  required: true

--- a/openshift/templates/api/cap/minio-eagle-cwu-benchmark.bc.yaml
+++ b/openshift/templates/api/cap/minio-eagle-cwu-benchmark.bc.yaml
@@ -1,0 +1,90 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: minio-benchmark
+  creationTimestamp: 
+objects:
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    name: ubuntu
+    creationTimestamp: 
+    labels:
+      shared: 'true'
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - name: '16.04'
+      annotations: 
+      from:
+        kind: DockerImage
+        name: ubuntu:16.04
+      importPolicy: {}
+      referencePolicy:
+        type: Source
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    name: "${NAME}"
+    creationTimestamp: 
+    labels:
+      shared: 'true'
+    annotations:
+      description: Keeps track of changes in the application image
+  spec:
+    lookupPolicy:
+      local: false
+    tags: []
+- kind: BuildConfig
+  apiVersion: v1
+  metadata:
+    name: "${NAME}"
+    labels:
+      app: "${NAME}"
+      buildconfig: "${NAME}"
+  spec:
+    source:
+      type: Git
+      git:
+        uri: "${SOURCE_REPOSITORY_URL}"
+        ref: "${GIT_REF}"
+      contextDir: "${SOURCE_CONTEXT_DIR}"
+    strategy:
+      type: Docker
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: ubuntu:16.04
+    output:
+      to:
+        kind: ImageStreamTag
+        name: "${NAME}:${VERSION}"
+    completionDeadlineSeconds: 600
+    triggers:
+    - type: ConfigChange
+    - type: ImageChange
+parameters:
+- name: NAME
+  displayName: Name
+  description: The name assigned to all of the objects defined in this template.
+  required: true
+  value: minio-benchmark
+- name: SOURCE_REPOSITORY_URL
+  displayName: Git Repo URL
+  description: The URL to the Git repository.
+  required: true
+  value: https://github.com/bcgov/cap-eagle-helper-pods.git
+- name: VERSION
+  required: true
+  value: 'stable'
+- name: GIT_REF
+  displayName: Git Reference
+  description: The git reference or branch.
+  required: true
+  value: master
+- name: SOURCE_CONTEXT_DIR
+  displayName: Source Context Directory
+  description: The source context directory.
+  required: false
+  value: docker-images/minio-benchmark

--- a/openshift/templates/api/cap/minio-eagle-cwu-benchmark.dc.yaml
+++ b/openshift/templates/api/cap/minio-eagle-cwu-benchmark.dc.yaml
@@ -1,0 +1,92 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: ${NAME}
+objects:
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        description: Defines how to deploy a ubuntu container for benchmarking minio
+      generation: 1
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        app: ${NAME}
+        deploymentconfig: ${NAME}
+      strategy:
+        activeDeadlineSeconds: 21600
+        recreateParams:
+          timeoutSeconds: 600
+        resources: {}
+        type: Recreate
+      triggers:
+      - type: ConfigChange
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - "${NAME}"
+          from:
+            kind: ImageStreamTag
+            name: "${IMAGESTREAM}"
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: ${NAME}
+            deploymentconfig: ${NAME}
+        spec:
+          containers:
+            - env:
+                - name: MINIO_ACCESS_KEY
+                  value: ${MINIO_ACCESS_KEY}
+                - name: MINIO_SECRET_KEY
+                  value: ${MINIO_SECRET_KEY}
+              image: ''
+              imagePullPolicy: Always
+              name: ${NAME}
+              resources:
+                limits:
+                  cpu: 150m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              command: ["./s3-benchmark"]
+              args: ["-a", "${MINIO_ACCESS_KEY}", "-s", "${MINIO_SECRET_KEY}", "-u", "${MINIO_SERVER_ADDRESS}", "-z", "${MINIO_OBJECT_SIZE}"]
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      test: false
+parameters:
+- name: NAME
+  displayName: Name to apply to objects in the template
+  value: cap-minio-eagle-dev-benchmark
+  required: true
+- name: IMAGESTREAM
+  displayName: ImageStream to deploy, built from buildconfig template
+  value: minio-benchmark:stable
+  required: true
+- name: MINIO_SERVER_ADDRESS
+  displayName: Address of minio server
+  value: https://minioserver.domain.com
+  required: true
+- name: MINIO_ACCESS_KEY
+  displayName: Minio access key for accessing server to be benchmarked
+  required: true
+- name: MINIO_SECRET_KEY
+  displayName: Minio secret key for accessing server to be benchmarked
+  required: true
+- name: MINIO_OBJECT_SIZE
+  displayName: Object size to use for benchmarking. In bytes with postfix K, M, and G (default "1M")
+  value: 1M
+  required: true

--- a/openshift/templates/api/cap/minio-eagle-cwu-local.dc.yaml
+++ b/openshift/templates/api/cap/minio-eagle-cwu-local.dc.yaml
@@ -1,0 +1,164 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: ${NAME}
+objects:
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        description: Defines how to deploy the minio server
+      generation: 1
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        app: ${NAME}
+        deploymentconfig: ${NAME}
+      strategy:
+        activeDeadlineSeconds: 21600
+        recreateParams:
+          timeoutSeconds: 600
+        resources: {}
+        type: Recreate
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: ${NAME}
+            deploymentconfig: ${NAME}
+        spec:
+          containers:
+            - env:
+                - name: MINIO_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: MINIO_ACCESS_KEY
+                      name: minio-local-keys
+                - name: MINIO_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: MINIO_SECRET_KEY
+                      name: minio-local-keys
+                - name: MINIO_CONFIG_DIR
+                  value: /tmp
+                - name: MINIO_DATA_DIR
+                  # This is here due to minio image depending on /data existing with a PVC volume mount
+                  # Without it pre-existing minio tries to create this dir which it can't as it's not running as root
+                  #value: /data
+                  value: /opt/minio/s3/data
+              image: >-
+                172.50.0.2:5000/openshift/minio@sha256:02f81d40a3515ab8ba4a311d73849e046d5d06cc2d68db938b33af45906fdded
+              imagePullPolicy: Always
+              name: ${NAME}
+              ports:
+                - containerPort: 9000
+                  protocol: TCP
+              resources:
+                limits:
+                  cpu: 150m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+#              volumeMounts:
+#                - mountPath: /data
+#                  name: ${NAME}-docs-pvc-gf
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+#          volumes:
+#            - name: ${NAME}-docs-pvc-gf
+#              persistentVolumeClaim:
+#                claimName: ${NAME}-docs-pvc-gf
+      test: false
+      triggers:
+        - imageChangeParams:
+            containerNames:
+              - ${NAME}
+            from:
+              kind: ImageStreamTag
+              name: 'minio:stable'
+              namespace: openshift
+          type: ImageChange
+        - type: ConfigChange
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: minio-local-keys
+      labels:
+        app: "${NAME}"
+    stringData:
+      MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY}"
+      MINIO_SECRET_KEY: "${MINIO_SECRET_KEY}"
+#  - apiVersion: v1
+#    kind: PersistentVolumeClaim
+#    metadata:
+#      name: ${NAME}-docs-pvc-gf
+#      annotations:
+#        volume.beta.kubernetes.io/storage-class: gluster-file
+#        volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/glusterfs
+#    spec:
+#      accessModes:
+#      - ReadWriteMany
+#      resources:
+#        requests:
+#          storage: 1Gi
+  - apiVersion: v1
+    kind: Service
+    spec:
+      ports:
+        - name: 9000-tcp
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+      selector:
+        deploymentconfig: ${NAME}
+      sessionAffinity: None
+      type: ClusterIP
+    metadata:
+      annotations:
+        description: Exposes the minio server
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    spec:
+      port:
+        targetPort: 9000-tcp
+      tls:
+        termination: edge
+      to:
+        kind: Service
+        name: ${NAME}
+        weight: 100
+      wildcardPolicy: None
+    metadata:
+      annotations:
+        openshift.io/host.generated: 'true'
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+parameters:
+- name: NAME
+  displayName: Name to apply to objects in the template
+  value: cap-minio-eagle-dev-local
+  required: true
+- name: MINIO_ACCESS_KEY
+  displayName: Minio access key
+  generate: expression
+  from: "[a-zA-Z0-9]{8}"
+  required: true
+- name: MINIO_SECRET_KEY
+  displayName: Minio secret key
+  generate: expression
+  from: "[a-zA-Z0-9]{16}"
+  required: true


### PR DESCRIPTION
Contains
-terraform template for deploying the Azure storage backend
-deploymentconfigs for MinIO local and Azure backed instances. Note the local instance I couldn't get the PVC to bind for some reason, so I've commented this out as we probably don't need a persistent volume to validate that storage moved and to do some benchmarking
-minio-benchmark tool, with Dockerfile and buildconfig to create the image, and deploymentconfig to deploy the tool

Documentation on how to use all this is going up on Confluence today