### PR TITLE
Adding cap templates back into repo

### DIFF
--- a/openshift/templates/cap/minio-eagle-cwu-aws.dc.yaml
+++ b/openshift/templates/cap/minio-eagle-cwu-aws.dc.yaml
@@ -1,0 +1,149 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: ${NAME}
+objects:
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        app: ${NAME}
+        deploymentconfig: ${NAME}
+      strategy:
+        activeDeadlineSeconds: 21600
+        recreateParams:
+          timeoutSeconds: 600
+        resources: {}
+        type: Recreate
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: ${NAME}
+            deploymentconfig: ${NAME}
+        spec:
+          containers:
+            - env:
+                - name: MINIO_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: MINIO_AWS_ACCESS_KEY
+                      name: minio-aws-keys
+                - name: MINIO_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: MINIO_AWS_SECRET_KEY
+                      name: minio-aws-keys
+                - name: MINIO_MODE
+                  value: gateway s3
+                - name: MINIO_DATA_DIR
+                  value: ''
+              image: ''
+              imagePullPolicy: Always
+              name: ${NAME}
+              ports:
+                - containerPort: 9000
+                  protocol: TCP
+              resources:
+                limits:
+                  cpu: 150m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      test: false
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${NAME}
+            from:
+              kind: ImageStreamTag
+              name: "${IMAGESTREAM}"
+              namespace: "${NAMESPACE}"
+          type: ImageChange
+        - type: ConfigChange
+    metadata:
+      annotations:
+        description: Defines how to deploy the minio server
+      generation: 1
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: minio-aws-keys
+      labels:
+        app: "${NAME}"
+    stringData:
+      MINIO_AWS_ACCESS_KEY: "${MINIO_AWS_ACCESS_KEY}"
+      MINIO_AWS_SECRET_KEY: "${MINIO_AWS_SECRET_KEY}"
+  - apiVersion: v1
+    kind: Service
+    spec:
+      ports:
+        - name: 9000-tcp
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+      selector:
+        deploymentconfig: ${NAME}
+      sessionAffinity: None
+      type: ClusterIP
+    metadata:
+      annotations:
+        description: Exposes the minio server
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    spec:
+      port:
+        targetPort: 9000-tcp
+      tls:
+        termination: edge
+      to:
+        kind: Service
+        name: ${NAME}
+        weight: 100
+      wildcardPolicy: None
+    metadata:
+      annotations:
+        openshift.io/host.generated: 'true'
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+parameters:
+- name: NAME
+  displayName: Name to apply to objects in the template
+  value: cap-minio-eagle-dev-aws
+  required: true
+- name: IMAGESTREAM
+  displayName: Minio image to deploy
+  value: minio:latest
+  required: true
+- name: NAMESPACE
+  displayName: Project name where image resides
+  value: oabrei-tools
+  required: true
+- name: MINIO_AWS_ACCESS_KEY
+  displayName: Minio AWS access key
+  generate: expression
+  from: "[a-zA-Z0-9]{8}"
+  required: true
+- name: MINIO_AWS_SECRET_KEY
+  displayName: Minio AWS secret key
+  generate: expression
+  from: "[a-zA-Z0-9]{16}"
+  required: true

--- a/openshift/templates/cap/minio-eagle-cwu-azure.dc.yaml
+++ b/openshift/templates/cap/minio-eagle-cwu-azure.dc.yaml
@@ -1,0 +1,149 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: ${NAME}
+objects:
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        app: ${NAME}
+        deploymentconfig: ${NAME}
+      strategy:
+        activeDeadlineSeconds: 21600
+        recreateParams:
+          timeoutSeconds: 600
+        resources: {}
+        type: Recreate
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: ${NAME}
+            deploymentconfig: ${NAME}
+        spec:
+          containers:
+            - env:
+                - name: MINIO_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: MINIO_AZURE_ACCESS_KEY
+                      name: minio-azure-keys
+                - name: MINIO_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: MINIO_AZURE_SECRET_KEY
+                      name: minio-azure-keys
+                - name: MINIO_MODE
+                  value: "gateway azure"
+                - name: MINIO_DATA_DIR
+                  value: ''
+              image: ''
+              imagePullPolicy: Always
+              name: ${NAME}
+              ports:
+                - containerPort: 9000
+                  protocol: TCP
+              resources:
+                limits:
+                  cpu: 150m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      test: false
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${NAME}
+            from:
+              kind: ImageStreamTag
+              name: "${IMAGESTREAM}"
+              namespace: "${NAMESPACE}"
+          type: ImageChange
+        - type: ConfigChange
+    metadata:
+      annotations:
+        description: Defines how to deploy the minio server
+      generation: 1
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: minio-azure-keys
+      labels:
+        app: "${NAME}"
+    stringData:
+      MINIO_AZURE_ACCESS_KEY: "${MINIO_AZURE_ACCESS_KEY}"
+      MINIO_AZURE_SECRET_KEY: "${MINIO_AZURE_SECRET_KEY}"
+  - apiVersion: v1
+    kind: Service
+    spec:
+      ports:
+        - name: 9000-tcp
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+      selector:
+        deploymentconfig: ${NAME}
+      sessionAffinity: None
+      type: ClusterIP
+    metadata:
+      annotations:
+        description: Exposes the minio server
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    spec:
+      port:
+        targetPort: 9000-tcp
+      tls:
+        termination: edge
+      to:
+        kind: Service
+        name: ${NAME}
+        weight: 100
+      wildcardPolicy: None
+    metadata:
+      annotations:
+        openshift.io/host.generated: 'true'
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+parameters:
+- name: NAME
+  displayName: Name to apply to objects in the template
+  value: cap-minio-eagle-dev-azure
+  required: true
+- name: IMAGESTREAM
+  displayName: Minio image to deploy
+  value: minio:latest
+  required: true
+- name: NAMESPACE
+  displayName: Project name where image resides
+  value: oabrei-tools
+  required: true
+- name: MINIO_AZURE_ACCESS_KEY
+  displayName: Minio Azure access key
+  generate: expression
+  from: "[a-zA-Z0-9]{8}"
+  required: true
+- name: MINIO_AZURE_SECRET_KEY
+  displayName: Minio Azure secret key
+  generate: expression
+  from: "[a-zA-Z0-9]{16}"
+  required: true

--- a/openshift/templates/cap/minio-eagle-cwu-benchmark.bc.yaml
+++ b/openshift/templates/cap/minio-eagle-cwu-benchmark.bc.yaml
@@ -1,0 +1,92 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: minio-benchmark
+  creationTimestamp: 
+objects:
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    name: ubuntu
+    creationTimestamp: 
+    labels:
+      shared: 'true'
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - name: '16.04'
+      annotations: 
+      from:
+        kind: DockerImage
+        name: ubuntu:16.04
+      importPolicy: {}
+      referencePolicy:
+        type: Source
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    name: "${NAME}"
+    creationTimestamp: 
+    labels:
+      shared: 'true'
+    annotations:
+      description: Keeps track of changes in the application image
+  spec:
+    lookupPolicy:
+      local: false
+    tags: []
+- kind: BuildConfig
+  apiVersion: v1
+  metadata:
+    name: "${NAME}"
+    labels:
+      app: "${NAME}"
+      buildconfig: "${NAME}"
+  spec:
+    source:
+      type: Git
+      git:
+        uri: "${SOURCE_REPOSITORY_URL}"
+        ref: "${GIT_REF}"
+      contextDir: "${SOURCE_CONTEXT_DIR}"
+    strategy:
+      type: Docker
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: ubuntu:16.04
+    output:
+      to:
+        kind: ImageStreamTag
+        name: "${NAME}:${VERSION}"
+    completionDeadlineSeconds: 600
+    triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+parameters:
+- name: NAME
+  displayName: Name
+  description: The name assigned to all of the objects defined in this template.
+  required: true
+  value: minio-benchmark
+- name: SOURCE_REPOSITORY_URL
+  displayName: Git Repo URL
+  description: The URL to the Git repository.
+  required: true
+  value: https://github.com/bcgov/cap-eagle-helper-pods.git
+- name: VERSION
+  required: true
+  value: 'stable'
+- name: GIT_REF
+  displayName: Git Reference
+  description: The git reference or branch.
+  required: true
+  value: master
+- name: SOURCE_CONTEXT_DIR
+  displayName: Source Context Directory
+  description: The source context directory.
+  required: false
+  value: docker-images/minio-benchmark

--- a/openshift/templates/cap/minio-eagle-cwu-benchmark.dc.yaml
+++ b/openshift/templates/cap/minio-eagle-cwu-benchmark.dc.yaml
@@ -1,0 +1,92 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: ${NAME}
+objects:
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        description: Defines how to deploy a ubuntu container for benchmarking minio
+      generation: 1
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        app: ${NAME}
+        deploymentconfig: ${NAME}
+      strategy:
+        activeDeadlineSeconds: 21600
+        recreateParams:
+          timeoutSeconds: 600
+        resources: {}
+        type: Recreate
+      triggers:
+      - type: ConfigChange
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - "${NAME}"
+          from:
+            kind: ImageStreamTag
+            name: "${IMAGESTREAM}"
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: ${NAME}
+            deploymentconfig: ${NAME}
+        spec:
+          containers:
+            - env:
+                - name: MINIO_ACCESS_KEY
+                  value: ${MINIO_ACCESS_KEY}
+                - name: MINIO_SECRET_KEY
+                  value: ${MINIO_SECRET_KEY}
+              image: ''
+              imagePullPolicy: Always
+              name: ${NAME}
+              resources:
+                limits:
+                  cpu: 150m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              command: ["./s3-benchmark"]
+              args: ["-a", "${MINIO_ACCESS_KEY}", "-s", "${MINIO_SECRET_KEY}", "-u", "${MINIO_SERVER_ADDRESS}", "-z", "${MINIO_OBJECT_SIZE}"]
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+      test: false
+parameters:
+- name: NAME
+  displayName: Name to apply to objects in the template
+  value: cap-minio-eagle-dev-benchmark
+  required: true
+- name: IMAGESTREAM
+  displayName: ImageStream to deploy, built from buildconfig template
+  value: minio-benchmark:stable
+  required: true
+- name: MINIO_SERVER_ADDRESS
+  displayName: Address of minio server
+  value: https://minioserver.domain.com
+  required: true
+- name: MINIO_ACCESS_KEY
+  displayName: Minio access key for accessing server to be benchmarked
+  required: true
+- name: MINIO_SECRET_KEY
+  displayName: Minio secret key for accessing server to be benchmarked
+  required: true
+- name: MINIO_OBJECT_SIZE
+  displayName: Object size to use for benchmarking. In bytes with postfix K, M, and G (default "1M")
+  value: 1M
+  required: true

--- a/openshift/templates/cap/minio-eagle-cwu-benchmark.pod.yaml
+++ b/openshift/templates/cap/minio-eagle-cwu-benchmark.pod.yaml
@@ -1,0 +1,63 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: ${NAME}
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      annotations:
+        description: Defines how to deploy a ubuntu container for benchmarking minio
+      generation: 1
+      name: "${NAME}"
+      creationTimestamp: 
+      labels:
+        app: ${NAME}
+    spec:
+      containers:
+        - env:
+            - name: MINIO_ACCESS_KEY
+              value: ${MINIO_ACCESS_KEY}
+            - name: MINIO_SECRET_KEY
+              value: ${MINIO_SECRET_KEY}
+          image: '${IMAGESTREAM}'
+          imagePullPolicy: Always
+          name: ${NAME}
+          resources:
+            limits:
+              cpu: 150m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          command: ["./s3-benchmark"]
+          args: ["-a", "${MINIO_ACCESS_KEY}", "-s", "${MINIO_SECRET_KEY}", "-u", "${MINIO_SERVER_ADDRESS}", "-z", "${MINIO_OBJECT_SIZE}"]
+      restartPolicy: Never
+      activeDeadlineSeconds: 900
+      dnsPolicy: ClusterFirst
+    status: {}
+parameters:
+- name: NAME
+  displayName: Name to apply to objects in the template
+  value: cap-minio-eagle-dev-benchmark
+  required: true
+- name: IMAGESTREAM
+  displayName: ImageStream to deploy, built from buildconfig template
+  value: registry/minio-benchmark:stable
+  required: true
+- name: MINIO_SERVER_ADDRESS
+  displayName: Address of minio server
+  value: https://minioserver.domain.com
+  required: true
+- name: MINIO_ACCESS_KEY
+  displayName: Minio access key for accessing server to be benchmarked
+  required: true
+- name: MINIO_SECRET_KEY
+  displayName: Minio secret key for accessing server to be benchmarked
+  required: true
+- name: MINIO_OBJECT_SIZE
+  displayName: Object size to use for benchmarking. In bytes with postfix K, M, and G (default "1M")
+  value: 1M
+  required: true

--- a/openshift/templates/cap/minio-eagle-cwu-local.dc.yaml
+++ b/openshift/templates/cap/minio-eagle-cwu-local.dc.yaml
@@ -1,0 +1,167 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: ${NAME}
+objects:
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        description: Defines how to deploy the minio server
+      generation: 1
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 10
+      selector:
+        app: ${NAME}
+        deploymentconfig: ${NAME}
+      strategy:
+        activeDeadlineSeconds: 21600
+        recreateParams:
+          timeoutSeconds: 600
+        resources: {}
+        type: Recreate
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: ${NAME}
+            deploymentconfig: ${NAME}
+        spec:
+          containers:
+            - env:
+                - name: MINIO_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: MINIO_ACCESS_KEY
+                      name: minio-local-keys
+                - name: MINIO_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: MINIO_SECRET_KEY
+                      name: minio-local-keys
+                - name: MINIO_DATA_DIR
+                  value: /data
+              image: ''
+              imagePullPolicy: Always
+              name: ${NAME}
+              ports:
+                - containerPort: 9000
+                  protocol: TCP
+              resources:
+                limits:
+                  cpu: 150m
+                  memory: 256Mi
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              volumeMounts:
+                - mountPath: /data
+                  name: ${NAME}-docs-pvc-gf
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - name: ${NAME}-docs-pvc-gf
+              persistentVolumeClaim:
+                claimName: ${NAME}-docs-pvc-gf
+      test: false
+      triggers:
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${NAME}
+            from:
+              kind: ImageStreamTag
+              name: "${IMAGESTREAM}"
+              namespace: "${NAMESPACE}"
+          type: ImageChange
+        - type: ConfigChange
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: minio-local-keys
+      labels:
+        app: "${NAME}"
+    stringData:
+      MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY}"
+      MINIO_SECRET_KEY: "${MINIO_SECRET_KEY}"
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ${NAME}-docs-pvc-gf
+      annotations:
+        volume.beta.kubernetes.io/storage-class: gluster-file
+        volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/glusterfs
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 2Gi
+  - apiVersion: v1
+    kind: Service
+    spec:
+      ports:
+        - name: 9000-tcp
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+      selector:
+        deploymentconfig: ${NAME}
+      sessionAffinity: None
+      type: ClusterIP
+    metadata:
+      annotations:
+        description: Exposes the minio server
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    spec:
+      port:
+        targetPort: 9000-tcp
+      tls:
+        termination: edge
+      to:
+        kind: Service
+        name: ${NAME}
+        weight: 100
+      wildcardPolicy: None
+    metadata:
+      annotations:
+        openshift.io/host.generated: 'true'
+      labels:
+        app: ${NAME}
+      name: ${NAME}
+parameters:
+- name: NAME
+  displayName: Name to apply to objects in the template
+  value: cap-minio-eagle-dev-local
+  required: true
+- name: IMAGESTREAM
+  displayName: Minio image to deploy
+  value: minio:latest
+  required: true
+- name: NAMESPACE
+  displayName: Project name where image resides
+  value: oabrei-tools
+  required: true
+- name: MINIO_ACCESS_KEY
+  displayName: Minio access key
+  generate: expression
+  from: "[a-zA-Z0-9]{8}"
+  required: true
+- name: MINIO_SECRET_KEY
+  displayName: Minio secret key
+  generate: expression
+  from: "[a-zA-Z0-9]{16}"
+  required: true


### PR DESCRIPTION
- Adding accidentally clobbered cap templates back
- Fixed up missing MINIO_DATA_DIR env for gateway mode
- Added automatic back to triggers so all templates deploy/build after processing