### PR TITLE
Cleaned up dup settings

### DIFF
--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_IBM/api/dev/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_IBM/api/dev/api-3-nodejs-dc.params
@@ -7,4 +7,3 @@ DATABASE_SERVICE_NAME=cap-clement-ibm-api-mongodb
 APP_IMAGE_NAME=cap-clement-ibm-api
 APP_IMAGE_NAMESPACE=oabrei-dev
 APP_DEPLOYMENT_TAG=dev
-NODE_ENV=development

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_IBM/api/prod/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_IBM/api/prod/api-3-nodejs-dc.params
@@ -7,4 +7,3 @@ DATABASE_SERVICE_NAME=cap-clement-ibm-api-mongodb
 APP_IMAGE_NAME=cap-clement-ibm-api
 APP_IMAGE_NAMESPACE=oabrei-prod
 APP_DEPLOYMENT_TAG=prod
-NODE_ENV=development

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_IBM/api/test/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_IBM/api/test/api-3-nodejs-dc.params
@@ -7,4 +7,3 @@ DATABASE_SERVICE_NAME=cap-clement-ibm-api-mongodb
 APP_IMAGE_NAME=cap-clement-ibm-api
 APP_IMAGE_NAMESPACE=oabrei-test
 APP_DEPLOYMENT_TAG=test
-NODE_ENV=development

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_KAMLOOPS/api/dev/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_KAMLOOPS/api/dev/api-3-nodejs-dc.params
@@ -7,4 +7,3 @@ DATABASE_SERVICE_NAME=cap-clement-kamloops-api-mongodb
 APP_IMAGE_NAME=cap-clement-kamloops-api
 APP_IMAGE_NAMESPACE=oabrei-dev
 APP_DEPLOYMENT_TAG=dev
-NODE_ENV=development

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_KAMLOOPS/api/prod/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_KAMLOOPS/api/prod/api-3-nodejs-dc.params
@@ -7,4 +7,3 @@ DATABASE_SERVICE_NAME=cap-clement-kamloops-api-mongodb
 APP_IMAGE_NAME=cap-clement-kamloops-api
 APP_IMAGE_NAMESPACE=oabrei-prod
 APP_DEPLOYMENT_TAG=prod
-NODE_ENV=development

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_KAMLOOPS/api/test/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_CLEMENT_KAMLOOPS/api/test/api-3-nodejs-dc.params
@@ -7,4 +7,3 @@ DATABASE_SERVICE_NAME=cap-clement-kamloops-api-mongodb
 APP_IMAGE_NAME=cap-clement-kamloops-api
 APP_IMAGE_NAMESPACE=oabrei-test
 APP_DEPLOYMENT_TAG=test
-NODE_ENV=development

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_DATA_GENERATOR_DEMO/api/dev/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_DATA_GENERATOR_DEMO/api/dev/api-3-nodejs-dc.params
@@ -7,4 +7,3 @@ DATABASE_SERVICE_NAME=cap-data-generator-demo-api-mongodb
 APP_IMAGE_NAME=cap-data-generator-demo-api
 APP_IMAGE_NAMESPACE=oabrei-dev
 APP_DEPLOYMENT_TAG=dev
-NODE_ENV=development

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_DATA_GENERATOR_DEMO/api/prod/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_DATA_GENERATOR_DEMO/api/prod/api-3-nodejs-dc.params
@@ -7,4 +7,3 @@ DATABASE_SERVICE_NAME=cap-data-generator-demo-api-mongodb
 APP_IMAGE_NAME=cap-data-generator-demo-api
 APP_IMAGE_NAMESPACE=oabrei-prod
 APP_DEPLOYMENT_TAG=prod
-NODE_ENV=development

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_DATA_GENERATOR_DEMO/api/test/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_DATA_GENERATOR_DEMO/api/test/api-3-nodejs-dc.params
@@ -7,4 +7,3 @@ DATABASE_SERVICE_NAME=cap-data-generator-demo-api-mongodb
 APP_IMAGE_NAME=cap-data-generator-demo-api
 APP_IMAGE_NAMESPACE=oabrei-test
 APP_DEPLOYMENT_TAG=test
-NODE_ENV=development


### PR DESCRIPTION
The settings were already set up in the build config.  Adding them to the deployment config was unnecessary.  Fixed.