### PR TITLE
Fix params

### DIFF
--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_BCGOV_AZURE/admin/dev/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_BCGOV_AZURE/admin/dev/admin-4-angular-on-nginx-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-bcgov-azure-admin
 GROUP_NAME=cap-bcgov-azure-epic
 IMAGE_NAMESPACE=tnhlex-dev
-APPLICATION_DOMAIN=cap-bcgov-azure-admin-tnhlex-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
+APPLICATION_DOMAIN=cap-bcgov-azure-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
 TAG_NAME=dev
-REMOTE_API_PATH=https://cap-bcgov-azure-admin-tnhlex-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/api
-REMOTE_PUBLIC_PATH=https://cap-bcgov-azure-admin-tnhlex-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
+REMOTE_API_PATH=https://cap-bcgov-azure-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/api
+REMOTE_PUBLIC_PATH=https://cap-bcgov-azure-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_BCGOV_AZURE/api/dev/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_BCGOV_AZURE/api/dev/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-bcgov-azure-api
 GROUP_NAME=cap-bcgov-azure-epic
-APPLICATION_DOMAIN=cap-bcgov-azure-admin-tnhlex-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
-MINIO_HOST=cap-bcgov-azure-admin-tnhlex-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
+APPLICATION_DOMAIN=cap-bcgov-azure-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
+MINIO_HOST=cap-bcgov-azure-api-minio
 MINIO_SECRET_NAME=cap-bcgov-azure-api-minio-keys
 DATABASE_SERVICE_NAME=cap-bcgov-azure-api-mongodb
 APP_IMAGE_NAME=cap-bcgov-azure-api

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_BCGOV_AZURE/api/prod/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_BCGOV_AZURE/api/prod/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-bcgov-azure-api
 GROUP_NAME=cap-bcgov-azure-epic
 APPLICATION_DOMAIN=cap-bcgov-azure-prod.pathfinder.gov.bc.ca
-MINIO_HOST=cap-bcgov-azure-api-minio-tnhlex-prod.pathfinder.gov.bc.ca
+MINIO_HOST=cap-bcgov-azure-api-minio
 MINIO_SECRET_NAME=cap-bcgov-azure-api-minio-keys
 DATABASE_SERVICE_NAME=cap-bcgov-azure-api-mongodb
 APP_IMAGE_NAME=cap-bcgov-azure-api

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_BCGOV_AZURE/api/test/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_BCGOV_AZURE/api/test/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-bcgov-azure-api
 GROUP_NAME=cap-bcgov-azure-epic
 APPLICATION_DOMAIN=cap-bcgov-azure-test.pathfinder.gov.bc.ca
-MINIO_HOST=cap-bcgov-azure-api-minio-tnhlex-dev.pathfinder.gov.bc.ca
+MINIO_HOST=cap-bcgov-azure-api-minio
 MINIO_SECRET_NAME=cap-bcgov-azure-api-minio-keys
 DATABASE_SERVICE_NAME=cap-bcgov-azure-api-mongodb
 APP_IMAGE_NAME=cap-bcgov-azure-api

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_BCGOV_AZURE/public/dev/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_BCGOV_AZURE/public/dev/public-4-angular-on-nginx-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-bcgov-azure-public
 GROUP_NAME=cap-bcgov-azure-epic
 IMAGE_NAMESPACE=tnhlex-dev
-APPLICATION_DOMAIN=cap-bcgov-azure-admin-tnhlex-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
+APPLICATION_DOMAIN=cap-bcgov-azure-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
 TAG_NAME=dev
-REMOTE_API_PATH=https://cap-bcgov-azure-admin-tnhlex-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/api/public
-REMOTE_ADMIN_PATH=https://cap-bcgov-azure-admin-tnhlex-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/admin/
+REMOTE_API_PATH=https://cap-bcgov-azure-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/api/public
+REMOTE_ADMIN_PATH=https://cap-bcgov-azure-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_IBM/admin/dev/admin-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_IBM/admin/dev/admin-4-angular-on-nginx-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-ibm-admin
 GROUP_NAME=cap-ibm-epic
 IMAGE_NAMESPACE=oabrei-dev
-APPLICATION_DOMAIN=cap-ibm-admin-oabrei-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
+APPLICATION_DOMAIN=cap-ibm-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
 TAG_NAME=dev
-REMOTE_API_PATH=https://cap-ibm-admin-oabrei-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/api
-REMOTE_PUBLIC_PATH=https://cap-ibm-admin-oabrei-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
+REMOTE_API_PATH=https://cap-ibm-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/api
+REMOTE_PUBLIC_PATH=https://cap-ibm-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_IBM/api/dev/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_IBM/api/dev/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-ibm-api
 GROUP_NAME=cap-ibm-epic
-APPLICATION_DOMAIN=cap-ibm-admin-oabrei-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
-MINIO_HOST=cap-ibm-admin-oabrei-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
+APPLICATION_DOMAIN=cap-ibm-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
+MINIO_HOST=cap-ibm-api-minio
 MINIO_SECRET_NAME=cap-ibm-api-minio-keys
 DATABASE_SERVICE_NAME=cap-ibm-api-mongodb
 APP_IMAGE_NAME=cap-ibm-api

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_IBM/api/prod/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_IBM/api/prod/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-ibm-api
 GROUP_NAME=cap-ibm-epic
 APPLICATION_DOMAIN=cap-ibm-prod.pathfinder.gov.bc.ca
-MINIO_HOST=cap-ibm-api-minio-oabrei-prod.pathfinder.gov.bc.ca
+MINIO_HOST=cap-ibm-api-minio
 MINIO_SECRET_NAME=cap-ibm-api-minio-keys
 DATABASE_SERVICE_NAME=cap-ibm-api-mongodb
 APP_IMAGE_NAME=cap-ibm-api

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_IBM/api/test/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_IBM/api/test/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-ibm-api
 GROUP_NAME=cap-ibm-epic
 APPLICATION_DOMAIN=cap-ibm-test.pathfinder.gov.bc.ca
-MINIO_HOST=cap-ibm-api-minio-oabrei-dev.pathfinder.gov.bc.ca
+MINIO_HOST=cap-ibm-api-minio
 MINIO_SECRET_NAME=cap-ibm-api-minio-keys
 DATABASE_SERVICE_NAME=cap-ibm-api-mongodb
 APP_IMAGE_NAME=cap-ibm-api

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_IBM/public/dev/public-4-angular-on-nginx-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_IBM/public/dev/public-4-angular-on-nginx-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-ibm-public
 GROUP_NAME=cap-ibm-epic
 IMAGE_NAMESPACE=oabrei-dev
-APPLICATION_DOMAIN=cap-ibm-admin-oabrei-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
+APPLICATION_DOMAIN=cap-ibm-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud
 TAG_NAME=dev
-REMOTE_API_PATH=https://cap-ibm-admin-oabrei-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/api/public
-REMOTE_ADMIN_PATH=https://cap-ibm-admin-oabrei-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/admin/
+REMOTE_API_PATH=https://cap-ibm-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/api/public
+REMOTE_ADMIN_PATH=https://cap-ibm-dev.clouddiscovery-01dea2606d71f7a3540418b505a890bc-0002.mon01.containers.appdomain.cloud/admin/

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS/api/dev/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS/api/dev/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-kamloops-api
 GROUP_NAME=cap-kamloops-epic
 APPLICATION_DOMAIN=cap-kamloops-dev.pathfinder.gov.bc.ca
-MINIO_HOST=cap-kamloops-api-minio-oabrei-dev.pathfinder.gov.bc.ca
+MINIO_HOST=cap-kamloops-api-minio
 MINIO_SECRET_NAME=cap-kamloops-api-minio-keys
 DATABASE_SERVICE_NAME=cap-kamloops-api-mongodb
 APP_IMAGE_NAME=cap-kamloops-api

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS/api/prod/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS/api/prod/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-kamloops-api
 GROUP_NAME=cap-kamloops-epic
 APPLICATION_DOMAIN=cap-kamloops-prod.pathfinder.gov.bc.ca
-MINIO_HOST=cap-kamloops-api-minio-oabrei-prod.pathfinder.gov.bc.ca
+MINIO_HOST=cap-kamloops-api-minio
 MINIO_SECRET_NAME=cap-kamloops-api-minio-keys
 DATABASE_SERVICE_NAME=cap-kamloops-api-mongodb
 APP_IMAGE_NAME=cap-kamloops-api

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS/api/test/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS/api/test/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-kamloops-api
 GROUP_NAME=cap-kamloops-epic
 APPLICATION_DOMAIN=cap-kamloops-test.pathfinder.gov.bc.ca
-MINIO_HOST=cap-kamloops-api-minio-oabrei-dev.pathfinder.gov.bc.ca
+MINIO_HOST=cap-kamloops-api-minio
 MINIO_SECRET_NAME=cap-kamloops-api-minio-keys
 DATABASE_SERVICE_NAME=cap-kamloops-api-mongodb
 APP_IMAGE_NAME=cap-kamloops-api

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS_DATA_GENERATOR_DEMO/api/dev/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS_DATA_GENERATOR_DEMO/api/dev/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-kamloops-data-generator-demo-api
 GROUP_NAME=cap-kamloops-data-generator-demo-epic
 APPLICATION_DOMAIN=cap-kamloops-data-generator-demo-dev.pathfinder.gov.bc.ca
-MINIO_HOST=cap-kamloops-data-generator-demo-api-minio-oabrei-dev.pathfinder.gov.bc.ca
+MINIO_HOST=cap-kamloops-data-generator-demo-api-minio
 MINIO_SECRET_NAME=cap-kamloops-data-generator-demo-api-minio-keys
 DATABASE_SERVICE_NAME=cap-kamloops-data-generator-demo-api-mongodb
 APP_IMAGE_NAME=cap-kamloops-data-generator-demo-api

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS_DATA_GENERATOR_DEMO/api/prod/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS_DATA_GENERATOR_DEMO/api/prod/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-kamloops-data-generator-demo-api
 GROUP_NAME=cap-kamloops-data-generator-demo-epic
 APPLICATION_DOMAIN=cap-kamloops-data-generator-demo-prod.pathfinder.gov.bc.ca
-MINIO_HOST=cap-kamloops-data-generator-demo-api-minio-oabrei-prod.pathfinder.gov.bc.ca
+MINIO_HOST=cap-kamloops-data-generator-demo-api-minio
 MINIO_SECRET_NAME=cap-kamloops-data-generator-demo-api-minio-keys
 DATABASE_SERVICE_NAME=cap-kamloops-data-generator-demo-api-mongodb
 APP_IMAGE_NAME=cap-kamloops-data-generator-demo-api

--- a/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS_DATA_GENERATOR_DEMO/api/test/api-3-nodejs-dc.params
+++ b/openshift/setup-teardown/params/CUSTOM_SETTINGS/CAP_KAMLOOPS_DATA_GENERATOR_DEMO/api/test/api-3-nodejs-dc.params
@@ -1,7 +1,7 @@
 NAME=cap-kamloops-data-generator-demo-api
 GROUP_NAME=cap-kamloops-data-generator-demo-epic
 APPLICATION_DOMAIN=cap-kamloops-data-generator-demo-test.pathfinder.gov.bc.ca
-MINIO_HOST=cap-kamloops-data-generator-demo-api-minio-oabrei-test.pathfinder.gov.bc.ca
+MINIO_HOST=cap-kamloops-data-generator-demo-api-minio
 MINIO_SECRET_NAME=cap-kamloops-data-generator-demo-api-minio-keys
 DATABASE_SERVICE_NAME=cap-kamloops-data-generator-demo-api-mongodb
 APP_IMAGE_NAME=cap-kamloops-data-generator-demo-api

--- a/openshift/setup-teardown/setup-all.sh
+++ b/openshift/setup-teardown/setup-all.sh
@@ -166,6 +166,7 @@ deployPublic $(<${PUBLIC_ARGS_FILE});
 # Typically your-target-env is one of [dev, test, prod]
 
 ###################################################### SNIP #######################################################
+#oc tag your-tools-namespace/your-app-name-api-minio:latest your-tools-namespace/your-app-name-api-minio:your-target-env
 #oc tag your-tools-namespace/your-app-name-api:latest your-tools-namespace/your-app-name-api:your-target-env
 #oc tag your-tools-namespace/your-app-name-public:latest your-tools-namespace/your-app-name-public:your-target-env
 #oc tag your-tools-namespace/your-app-name-admin:latest your-tools-namespace/your-app-name-admin:your-target-env


### PR DESCRIPTION
Because we copied from the IBM settings, the errors in the IBM params propagated throughout.  This fixes a lot of the routing problems.

Affected deployments:
- azure
- ibm
- kamloops
- data gen demo

Also added a tag command hint for minio now that we're building it